### PR TITLE
feat: Find filenames without extensions (BBC release53)

### DIFF
--- a/apps/http-server/packages/generic/src/storage/fileStorage.ts
+++ b/apps/http-server/packages/generic/src/storage/fileStorage.ts
@@ -202,19 +202,19 @@ export class FileStorage extends Storage {
 		}
 	}
 	async deletePackage(paramPath: string): Promise<{ meta: ResponseMeta; body: any } | BadResponse> {
-		const fullPath = path.join(this._basePath, paramPath)
+		const fileInfo = await this.getFileInfo(paramPath)
 
-		if (!(await this.exists(fullPath))) {
-			return { code: 404, reason: 'Package not found' }
+		if (!fileInfo.found) {
+			return { code: fileInfo.code, reason: fileInfo.reason }
 		}
 
-		await fsUnlink(fullPath)
+		await fsUnlink(fileInfo.fullPath)
 
 		const meta: ResponseMeta = {
 			statusCode: 200,
 		}
 
-		return { meta, body: { message: `Deleted "${paramPath}"` } }
+		return { meta, body: { message: `Deleted "${fileInfo.fullPath}"` } }
 	}
 
 	private async exists(fullPath: string) {


### PR DESCRIPTION
## About Me

This pull request is posted on behalf of the BBC.

This is a rebase of https://github.com/Sofie-Automation/sofie-package-manager/pull/233 onto the BBC release53 branch.

## Type of Contribution

This is a Feature.

## Current Behavior

Filenames must match exactly for package manager to find them, even though CasparCG is capable of finding files without their extensions.

## New Behavior

If an exact match is not found, package manager will look for files that start with the name given, followed by a `.`, so `foo` will match `foo.mp4`, `foo.mov` etc.

## Testing Instructions

Upload a package. Refer to it in the rundown without its file extension. Ensure that preview, thumbnail etc. are generated as normal and that it is able to be played.

## Other Information

## Status

- [ ] PR is ready to be reviewed.
- [x] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://sofie-automation.github.io/sofie-core/)) has been added / updated.
